### PR TITLE
Small documentation fixes

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -147,7 +147,7 @@ Persons := [
     PostalAddress := Concatenation(
                        "Fachbereich Mathematik\n",
                        "TU Kaiserslautern\n",
-                       "Gottlieb-Daimler-Straﬂe 48\n",
+                       "Gottlieb-Daimler-Stra√üe 48\n",
                        "67663 Kaiserslautern\n",
                        "Germany" ),
     Place         := "Kaiserslautern, Germany",

--- a/doc/fining.bib
+++ b/doc/fining.bib
@@ -10,7 +10,7 @@
 @article{LaVa,
 	Author = {Lavrauw, Michel and Van de Voorde, Geertrui},
 	Title = {Field reduction and linear sets in finite geometry},
-	Journal = {to appear in AMS Contemp. Math}
+	Journal = {to appear in AMS Contemp. Math},
 	Year = {2013}}
 	
 	

--- a/doc/gpolygons.xml
+++ b/doc/gpolygons.xml
@@ -884,7 +884,7 @@ A&lt;sub>i&lt;/sub>&lt;sup>T&lt;/sup></Alt>. Now define the following subgroups 
 <Alt Only="HTML MathJax"><M>A(\infty) = \{(0,0,\gamma): \gamma \in GF(q)^2\}</M></Alt><Alt Not="HTML"><M>A(\infty) = (0,0,\gamma): \gamma \in GF(q)^2\}</M></Alt>
 <Alt Only="HTML noMathJax">A(&#8734;)= {(0,0,&#947;) &#947; &#8712; GF(q)&lt;sup>2&lt;/sup> }</Alt>, and<P/>
 <Alt Only="HTML MathJax"><M>A^*(i) = \{(\alpha,b,\alpha K_t): \alpha \in GF(q)^2, b \in GF(q), i=1\ldots q\}</M></Alt>
-<Alt Not="HTML"><M>A^*(i) = \{(\alpha,\b,\alpha K_t): \alpha \in GF(q)^2, b \in GF(q), i=1\ldots q\}</M></Alt>
+<Alt Not="HTML"><M>A^*(i) = \{(\alpha,b,\alpha K_t): \alpha \in GF(q)^2, b \in GF(q), i=1\ldots q\}</M></Alt>
 <Alt Only="HTML noMathJax">A&lt;sup>*&lt;/sup>(i)= {(&#945;,b,&#945;K&lt;sub>i&lt;/sub>): &#945; &#8712; GF(q)&lt;sup>2&lt;/sup>, b &#8712; GF(q), i=1..q }</Alt> and
 <Alt Only="HTML MathJax"><M>A^*(\infty) = \{(0,b,\gamma): \gamma \in GF(q)^2, b \in GF(q)\}</M></Alt>
 <Alt Not="HTML"><M>A^*(\infty) = \{(0,b,\gamma): \gamma \in GF(q)^2, b \in GF(q)\}</M></Alt>


### PR DESCRIPTION
Three small documentation fixes.  The mixture of ISO8859-1 and UTF-8 characters in PackageInfo.g made poor Emacs lose its mind and try to apply some Japanese encoding with predictably bad results.
