### PR TITLE
Require cvec >= 2.7.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
         gap-branch:
           - master
           - stable-4.11
-          - stable-4.10
 
     steps:
       - uses: actions/checkout@v2

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -185,7 +185,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">=4.10",
   NeededOtherPackages := [
-          ["cvec", ">=2.7.4"],
+          ["cvec", ">=2.7.6"],
           ["Forms", ">=1.2.5"],
           ["GAPDoc", ">= 1.6.3"],
           ["GenSS", ">=1.6.6"],

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -14,5 +14,11 @@ gap> q := VectorSpaceToElement(ps, [1, 1, 0]*Z(8)^0);
 gap> ElationOfProjectiveSpace(l, p, q);
 < a collineation: <cmat 3x3 over GF(2,3)>, F^0>
 
+# verify SingerCycleCollineation does not run into an error,
+# at least when using cvec >= 2.7.6;
+# see <https://github.com/gap-packages/FinInG/issues/21>
+gap> SingerCycleCollineation(2, 2^6);
+< a collineation: <cmat 3x3 over GF(2,6)>, F^0>
+
 #
 gap> STOP_TEST("bugfix.tst", 1 );


### PR DESCRIPTION
This fixes SingerCycleCollineation for certain arguments.
