### PR TITLE
Support UnderlyingObject being declared as an attribute by other packages

### DIFF
--- a/lib/geometry.gd
+++ b/lib/geometry.gd
@@ -253,7 +253,11 @@ DeclareOperation( "Unwrap", [IsElementOfIncidenceStructure] );
 # three general operations. Methods to be installed for several filters.
 DeclareOperation( "ObjectToElement", [IsIncidenceStructure, IsPosInt, IsObject] );
 DeclareOperation( "ObjectToElement", [IsIncidenceStructure, IsObject] );
-DeclareOperation( "UnderlyingObject", [IsElementOfIncidenceStructure] );
+if IsBoundGlobal( "UnderlyingObject" ) and IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
+    DeclareAttribute( "UnderlyingObject", IsElementOfIncidenceStructure );
+else
+    DeclareOperation( "UnderlyingObject", [IsElementOfIncidenceStructure] );
+fi;
 
 DeclareGlobalFunction( "HashFuncForElements" );
 DeclareGlobalFunction( "HashFuncForSetElements" );


### PR DESCRIPTION
See https://github.com/homalg-project/homalg_project/issues/564 for some context.

This is a draft PR because I just want to see if the CI passes. If it does, I would implement the following approach for both `FinInG` and `homalg_project`:

1. Add the following piece of code (untested) to make the packages compatible with `UnderlyingObject` being either an operation or an attribute:

```
if IsBoundGlobal( "UnderlyingObject" ) and IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
    DeclareAttribute( "UnderlyingObject", ... );
else
    DeclareOperation( "UnderlyingObject", [ ... ] );
fi;
```

2. Make releases and see if everything passes.
3. Remove the case distinction and simply use `DeclareAttribute`.
4. Make releases and see if everything passes, again.