### PR TITLE
Declare UnderlyingObject as an attribute by default

### DIFF
--- a/lib/geometry.gd
+++ b/lib/geometry.gd
@@ -253,10 +253,10 @@ DeclareOperation( "Unwrap", [IsElementOfIncidenceStructure] );
 # three general operations. Methods to be installed for several filters.
 DeclareOperation( "ObjectToElement", [IsIncidenceStructure, IsPosInt, IsObject] );
 DeclareOperation( "ObjectToElement", [IsIncidenceStructure, IsObject] );
-if IsBoundGlobal( "UnderlyingObject" ) and IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
-    DeclareAttribute( "UnderlyingObject", IsElementOfIncidenceStructure );
-else
+if IsBoundGlobal( "UnderlyingObject" ) and not IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
     DeclareOperation( "UnderlyingObject", [IsElementOfIncidenceStructure] );
+else
+    DeclareAttribute( "UnderlyingObject", IsElementOfIncidenceStructure );
 fi;
 
 DeclareGlobalFunction( "HashFuncForElements" );

--- a/lib/liegeometry.gd
+++ b/lib/liegeometry.gd
@@ -77,7 +77,7 @@ DeclareOperation( "VectorSpaceToElement", [IsLieGeometry, IsCVecRep] );
 DeclareOperation( "VectorSpaceToElement", [IsLieGeometry, IsCMatRep] );
 
 
-#DeclareOperation( "UnderlyingObject", [IsElementOfLieGeometry] ); #made more general and moved to geometry.gd
+#DeclareAttribute( "UnderlyingObject", IsElementOfLieGeometry ); #made more general and moved to geometry.gd
 #DeclareOperation( "EmptySubspace", [IsClassicalPolarSpace] );
 #DeclareOperation( "EmptySubspace", [IsProjectiveSpace] );
 DeclareOperation( "EmptySubspace", [IsLieGeometry] );


### PR DESCRIPTION
but keep a certain amount of backwards compatibility by declaring it as an operation if some other package has declared it as an operation before.

Note: I don't need this here, I just think it makes sense to have the default consistent with homalg.