### PR TITLE
WIP: Add test for NiceMonomorphismByDomain

### DIFF
--- a/tst/misc.tst
+++ b/tst/misc.tst
@@ -1,0 +1,17 @@
+#
+gap> START_TEST("misc.tst");
+
+# test NiceMonomorphism for subgeometries, which uses hash tables
+gap> pg := PG(1,5^4);
+ProjectiveSpace(1, 625)
+gap> sub := CanonicalSubgeometryOfProjectiveSpace(pg, GF(5));
+Subgeometry PG(1, 5) of ProjectiveSpace(1, 625)
+gap> g := CollineationGroup(sub);
+The FinInG collineation group PGL(2,5) of Subgeometry PG(1, 5) of ProjectiveSpace(1, 625)
+gap> Size(g);
+480
+gap> Number([1..10], i -> PseudoRandom(g) in g);
+10
+
+#
+gap> STOP_TEST("misc.tst", 10000 );


### PR DESCRIPTION
This grew out of my attempt to fix issue #27 (the final fix is now PR #41).

As a first step, I added a test to exercise `NiceMonomorphismByDomain`, the only place calling the old orb hashtable API.

Unfortunately, the new test fails 😂 as in: `NiceMonomorphismByDomain` is maybe incorrect. I guess this underlines how important it is to have test cases for *all* code, even the "obviously" correct code.

Note that the test fails if one forces the parent of the group in question to compute its nice monomorphism first, i.e.: insert `NiceMonomorphism(Parent(g));` before the `Size(g)` to ensure that.

<s>So my idea of "simply" replacing the old by the new hashtable API is a no-go because I can't really test the change... gotta figure out what's wrong with this code first.</s> Actually after understanding what's going on, I decided the test is "good enough" to verify the hashtable related changes I made work right; I put them into PR #41)

CC @jdebeule 
