### PR TITLE
Require GAP >= 4.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
-          - stable-4.11
 
     steps:
       - uses: actions/checkout@v4

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -185,7 +185,7 @@ PackageDoc := rec(
 ##  Are there restrictions on the operating system for this package? Or does
 ##  the package need other packages to be available?
 Dependencies := rec(
-  GAP := ">=4.10",
+  GAP := ">=4.12",
   NeededOtherPackages := [
           ["cvec", ">=2.7.6"],
           ["Forms", ">=1.2.5"],


### PR DESCRIPTION
... as only that ships with a cvec new enough for FinInG

@jdebeule please merge